### PR TITLE
add general extension array work

### DIFF
--- a/proposal.md
+++ b/proposal.md
@@ -32,6 +32,29 @@ By dedicating time specifically to maintenance we hope to reduce the open issue
 backlog and increase the growth rate of new contributors, as pandas becomes an
 easier project to contribute to.
 
+### Extension Types
+
+Pandas Extension Types allow for extending NumPy types with custom
+data types and array storage. Pandas uses extension types internally for several
+type such as categorical, datetime with timezone and interval data, and provides
+an interface for 3rd-party libraries to define their own custom data types.
+
+Many parts of pandas still don't full handle such extension types, leading to
+special cases in the code (hurting maintainability), places where the data
+is unintentionally converted to a NumPy array (with possible performance
+implications) and missing functionalities for those data types.
+These problems are especially pronounced for nested data.
+
+We'd like to improve the handling of extension arrays throughout the library,
+making their behavior more consistent with the handling of NumPy arrays. We'll do this
+by cleaning up pandas' internals and adding new methods do the extension array interface.
+The goal is to better enable new extension type (such as a native string data type,
+see below) and to ensure that the existing types such as the integer data type with
+missing values support can be a full replacement for the default numpy-based type.
+
+This work can also involve reaching out to external parties (such as fletcher)
+to collaborate on refining their extension arrays.
+
 ### Native String Data Type
 
 Currently, pandas stores text data in an ``object``-dtype NumPy array.


### PR DESCRIPTION
I think it would be nice to list the general EA work explicitly, as there are still a lot of open issues around this, that currently only see slow improvement.

Thoughts?

I mention the native string data types as a related item, but we could also group both in a single section.